### PR TITLE
advance_example

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -14,5 +14,5 @@ Uses the fakerequests capabilities to create a small I2C temperature sensors dat
 look for the correct one.I
 
 .. literalinclude:: ../examples/fakerequests_advancedtest.py
-    :caption: examples/examples/fakerequests_advancedtest.py
+    :caption: examples/fakerequests_advancedtest.py
     :linenos:

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -6,3 +6,13 @@ Ensure your device works with this simple test.
 .. literalinclude:: ../examples/fakerequests_simpletest.py
     :caption: examples/fakerequests_simpletest.py
     :linenos:
+
+Advanced I2C test
+-----------------
+
+Uses the fakerequests capabilities to create a small I2C temperature sensors database, and
+look for the correct one.I
+
+.. literalinclude:: ../examples/fakerequests_advancedtest.py
+    :caption: examples/examples/fakerequests_advancedtest.py
+    :linenos:

--- a/examples/fakerequests_advancedtest.py
+++ b/examples/fakerequests_advancedtest.py
@@ -58,7 +58,9 @@ for find_sensor in sensor_choices:
         except ValueError:
             pass
     except Exception as e:
-        raise ImportError(f"Could not find the module {package} in your lib folder.") from e
+        raise ImportError(
+            f"Could not find the module {package} in your lib folder."
+        ) from e
 
 if found:
     print("Congratulations")

--- a/examples/fakerequests_advancedtest.py
+++ b/examples/fakerequests_advancedtest.py
@@ -52,14 +52,16 @@ for find_sensor in sensor_choices:
         try:
             sensor = variable(i2c)
             print(
-                f"The sensor {class_name} gives a temperature of {sensor.temperature} Celsius"
+                "The sensor {} gives a temperature of {} Celsius".format(
+                    class_name, sensor.temperature
+                )
             )
             found = True
         except ValueError:
             pass
     except Exception as e:
         raise ImportError(
-            f"Could not find the module {package} in your lib folder."
+            "Could not find the module {} in your lib folder.".format(package)
         ) from e
 
 if found:

--- a/examples/fakerequests_advancedtest.py
+++ b/examples/fakerequests_advancedtest.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2021 Jose David M
+#
+# SPDX-License-Identifier: Unlicense
+"""
+Example showing the use of Fake_requests to access a Temperature Sensor information
+Database. Inspired on the I2C buddy and a Discussion with Hugo Dahl
+"""
+import board
+from adafruit_fakerequests import Fake_Requests
+
+# Create the fakerequest request and get the temperature sensor definitions
+# It will look through the database and print the name of the sensor and
+# the temperature
+response = Fake_Requests("fakerequests_i2c_database.txt")
+definitions = response.text.split("\n")
+
+# We create the i2c object and set a flag to let us know if the sensor is found
+found = False
+i2c = board.I2C()
+
+# We look for all the sensor address and added to a list
+print("Looking for addresses")
+i2c.unlock()  # used here, to avoid problems with the I2C bus
+i2c.try_lock()
+sensor_address = int(i2c.scan()[-1])
+print("Sensor address is:", hex(sensor_address))
+i2c.unlock()  # unlock the bus
+
+# Create an empty list for the sensors found in the database
+sensor_choices = list()
+
+# Compare the sensor found vs the database. this is done because
+# we could have the case that the same address corresponds to
+# two or more temperature sensors
+for sensor in definitions:
+    elements = sensor.split(",")
+    if int(elements[0]) == sensor_address:
+        sensor_choices.append(sensor)
+
+# This is the main logic to found the sensor and try to
+# initiate it. It would raise some exceptions depending
+# on the situation. As an example this is not perfect
+# and only serves to show the library capabilities
+# and nothing more
+for find_sensor in sensor_choices:
+    module = find_sensor.split(",")
+    package = module[2]
+    class_name = str(module[3]).strip(" ")
+    try:
+        module = __import__(package)
+        variable = getattr(module, class_name)
+        try:
+            sensor = variable(i2c)
+            print(
+                f"The sensor {class_name} gives a temperature of {sensor.temperature} Celsius"
+            )
+            found = True
+        except ValueError:
+            pass
+    except ImportError:
+        raise Exception(f"Could not find the module {package} in your lib folder.")
+
+if found:
+    print("Congratulations")
+else:
+    print("We could not find a valid Temperature Sensor")

--- a/examples/fakerequests_advancedtest.py
+++ b/examples/fakerequests_advancedtest.py
@@ -57,8 +57,8 @@ for find_sensor in sensor_choices:
             found = True
         except ValueError:
             pass
-    except ImportError:
-        raise Exception(f"Could not find the module {package} in your lib folder.")
+    except Exception as e:
+        raise ImportError(f"Could not find the module {package} in your lib folder.") from e
 
 if found:
     print("Congratulations")

--- a/examples/fakerequests_i2c_database.txt
+++ b/examples/fakerequests_i2c_database.txt
@@ -1,0 +1,14 @@
+0x18,MCP9808 temp sensor,adafruit_mcp9808,MCP9808
+0x37,PCT2075 Temperature Sensor,adafruit_pct2075,PCT2075
+0x40,Si7021 Humidity/Temp sensor,adafruit_si7021,SI7021
+0x40,HTU21D-F Humidity/Temp Sensor,adafruit_htu21d,HTU21D
+0x40,HTU31D breakout,adafruit_htu31d,HTU31D
+0x44,SHT31 Humidity/Temp sensor,adafruit_shtc3,SHTC3
+0x38,AHT20 Temperature & Humidity Sensor,adafruit_ahtx0,AHTx0
+0x5C,AM2320 Humidity/Temp sensor,adafruit_am2320,AM2320
+0x44,SHT4x temperature and humidity sensors,adafruit_sht4x, SHT4x
+0x70,SHTC3 Humidity and Temperature Sensor,adafruit_shtc3,SHTC3
+0x48,TMP117 Temperature sensor,adafruit_tmp117,TMP117
+0x60,MPL115A2 I2C Barometric Pressure/Temperature Sensor,adafruit_mpl115a2,MPL115A2
+0x48,TC74 Digital Temperature Sensor,adafruit_tc74,TC74
+0x48,ADT7410 analog temperature Sensor,adafruit_adt7410,ADT7410

--- a/examples/fakerequests_i2c_database.txt.license
+++ b/examples/fakerequests_i2c_database.txt.license
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2021 Jose David M
+#
+# SPDX-License-Identifier: Unlicense


### PR DESCRIPTION
Solves #2.

This is an example of the use of fakerequests to create a simple database with I2C temperature sensors and look for the correct one.
As is an example for the fakerequests and not a library to get the correct temperature sensor, could have improvements. 

## Tests: 
This was tested in three different sensors, name will be indicated in the results,as this is the purpose of the example

```python
Adafruit CircuitPython 6.2.0 on 2021-04-05; Adafruit Feather RP2040 with rp2040
>>> import fakerequests_advancedtest
Looking for addresses
Sensor address is: 0x44
The sensor SHT4x gives a temperature of 25.3471 Celsius
Congratulations


Adafruit CircuitPython 6.2.0 on 2021-04-05; Adafruit Feather RP2040 with rp2040
>>> import fakerequests_advancedtest
Looking for addresses
Sensor address is: 0x40
The sensor SI7021 gives a temperature of 25.2977 Celsius
Congratulations

>>> import fakerequests_advancedtest
Looking for addresses
Sensor address is: 0x70
The sensor SHTC3 gives a temperature of 27.0 Celsius
Congratulations
```