### PR TITLE
add headers and status_code to response

### DIFF
--- a/adafruit_fakerequests.py
+++ b/adafruit_fakerequests.py
@@ -33,10 +33,20 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_FakeRequests.git"
 
 
 class Fake_Requests:
-    """For faking 'requests' using a local file instead of the network."""
+    """For faking 'requests' using a local file instead of the network.
 
-    def __init__(self, filename: str) -> None:
+    :param string filename: Name of the file to read.
+    :param dict headers: Headers to add to the faked response.
+    :param int status_code: Status code to use to the faked response.
+    """
+
+    def __init__(self, filename: str, headers=None, status_code=200) -> None:
         self._filename = filename
+        if headers is None:
+            self.headers = {"content-type": "application/json"}
+        else:
+            self.headers = headers
+        self.status_code = status_code
 
     def json(self) -> Any:
         """json parsed version for local requests."""

--- a/adafruit_fakerequests.py
+++ b/adafruit_fakerequests.py
@@ -24,7 +24,7 @@ Implementation Notes
 import json
 
 try:
-    from typing import Any
+    from typing import Any, Optional
 except ImportError:
     pass
 
@@ -40,7 +40,9 @@ class Fake_Requests:
     :param int status_code: Status code to use to the faked response.
     """
 
-    def __init__(self, filename: str, headers=None, status_code=200) -> None:
+    def __init__(
+        self, filename: str, headers: Optional[dict] = None, status_code: int = 200
+    ) -> None:
         self._filename = filename
         if headers is None:
             self.headers = {"content-type": "application/json"}


### PR DESCRIPTION
These are necessary in order for Fake_Request to work with current version of portalbase because it tries to access both `response.headers` and `resposne.status_code` inside of `check_response()` https://github.com/adafruit/Adafruit_CircuitPython_PortalBase/blob/main/adafruit_portalbase/network.py#L581

Also added parameter docstrings for new and existing args.